### PR TITLE
Settings: fixes the failure to see the settings and keybindings views

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,7 +17,7 @@
                         [
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/FoldComments/foldcomments.sublime-settings"},
+                                "args": {"file": "${packages}/Fold Comments/foldcomments.sublime-settings"},
                                 "caption": "FoldComments Settings – Default"
                             },
                             {
@@ -29,7 +29,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/FoldComments/Default (Windows).sublime-keymap",
+                                    "file": "${packages}/Fold Comments/Default (Windows).sublime-keymap",
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – Default"
@@ -37,7 +37,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/FoldComments/Default (OSX).sublime-keymap",
+                                    "file": "${packages}/Fold Comments/Default (OSX).sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – Default"
@@ -45,7 +45,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/FoldComments/Default (Linux).sublime-keymap",
+                                    "file": "${packages}/Fold Comments/Default (Linux).sublime-keymap",
                                     "platform": "Linux"
                                 },
                                 "caption": "Key Bindings – Default"


### PR DESCRIPTION
When the plugin is installed via sublime's package manager, sublime text was failing to show the setting panes. Once installed, it creates a file called `Fold Comments.sublime-package` but on the menu file we have no spaces in the paths.
