### PR TITLE
Un/Fold automatically when file is opened

### DIFF
--- a/foldcomments.py
+++ b/foldcomments.py
@@ -201,3 +201,15 @@ class UnfoldCommentsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         comments = CommentNodes(self.view)
         comments.unfold()
+
+class EventDump(sublime_plugin.EventListener):
+    def on_load(self, view):
+        comments = CommentNodes(view)
+        mode = load_settings('foldcomments.sublime-settings').get('fold_on_file_load')
+
+        # Bail if mode is neither 'fold' nor 'unfold'
+        if mode != 'fold' and mode != 'unfold':
+            return
+
+        # call comments.(un)?fold
+        getattr(comments, mode)()

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -35,5 +35,13 @@
 	 * @param {Number} baz
 	 * @return {Number} Foobar number
 	 */
-	"fold_doc_block_comments": true
+	"fold_doc_block_comments": true,
+
+	// Fold comments to this state, whenever a
+	// file is opened.
+	// Recognizes the values
+	//   - "fold"   : Folds all comments on_load
+  //   - "unfold" : Undfolds all comments on_load
+  //   - "off"		: Leaves the opened view untouched
+	"fold_on_file_load": "off"
 }


### PR DESCRIPTION
Hi there! :smiley: 
Great plugin; it does a great job and exactly what I was looking for. Well... :thinking: 
Always pressing the shortcut can become annoying. So here we go...

---
`Add: on_load handler to fold automatically when files are opened`
  - reads setting `fold_on_file_load`
    - "fold": Folds all comments on_load
    - "unfold": Undfolds all comments on_load
    - Every other value is ignored, i.e. view stays untouched *

[*] The standard value is "off" to ensure initial behavior to match that of prior versions (i.e. doing nothing)

Have a nice weekend!
rbeer